### PR TITLE
build: bump twine to 6.x for publish compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dev = [
     "tox~=4.11.3",
     "tox-pytest-summary~=0.1.2",
     "build~=1.2",
-    "twine~=4.0.2",
+    "twine~=6.2",
     "setuptools~=68.2.2",
     "wheel~=0.41.2",
 ]


### PR DESCRIPTION
Follow-up to #47. The `publish.yml` release job failed on 0.3.0:

```
twine 4.0.2 -> KeyError: 'license' (importlib_metadata 9.x)
```

twine 4.0.2 crashes reading its own `license` metadata under newer `importlib_metadata`. Bumps the dev pin `twine~=4.0.2` -> `twine~=6.2` so `make publish-pipy` works in CI. Verified locally: `twine 6.2.0` builds and `twine check` passes on both 0.3.0 artifacts.