### PR TITLE
release: 0.3.1 (twine fix + version bump)

### DIFF
--- a/eds4jinja2/__init__.py
+++ b/eds4jinja2/__init__.py
@@ -9,7 +9,7 @@ __docformat__ = "restructuredtext en"
 
 # The __version__ literal is read by pyproject.toml ([tool.setuptools.dynamic]) and by a
 # regex in /docs/conf.py — keep it a simple string assignment.
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __date__ = "2026-06-18"
 
 import logging


### PR DESCRIPTION
Cuts **0.3.1**, the first release that publishes cleanly via `publish.yml`.

0.3.0 was tagged/released but never reached PyPI — the publish job crashed on `twine 4.0.2` (`KeyError: 'license'` under `importlib_metadata` 9.x). The twine fix is already on master (#48); this PR is the version bump of record:

- `chore(release): 0.3.1`

Verified locally with the fixed twine: `python -m build` + `twine check` PASS on both 0.3.1 artifacts.

On merge: I tag `0.3.1` + cut the GitHub Release, which triggers `publish.yml` to test and publish to PyPI automatically. The stale 0.3.0 tag/release (never published) will be removed.