### PR TITLE
ci: bump actions to Node 24 majors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,9 +38,9 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Check out
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Set up Windows tooling
@@ -54,10 +54,10 @@ jobs:
     - name: Run tests
       run: make test-all
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: coverage.xml
+        files: coverage.xml
         env_vars: OS,PYTHON
         name: codecov-umbrella
         fail_ci_if_error: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,9 +20,9 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Check out
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - name: Install dependencies
@@ -31,10 +31,10 @@ jobs:
     - name: Run tests
       run: make test-all
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: coverage.xml
+        files: coverage.xml
         env_vars: OS,PYTHON
         name: codecov-umbrella
         fail_ci_if_error: true


### PR DESCRIPTION
Clears the Node.js 20 deprecation warning surfaced on the 0.3.1 publish run.

- `actions/checkout` v4 -> v5
- `actions/setup-python` v4 -> v6
- `codecov/codecov-action` v3 -> v5 (renames the `file` input to `files`)

Both `main.yml` (test matrix) and `publish.yml` updated. The `test` workflow runs on this PR and will validate the bumps before merge.