### PR TITLE
test+docs: real RDFFileDataSource tests, offline make_document, README rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # eds4jinja2
-An easy way to reports generation with Jinja2 templates. 
 
-With Embedded Datasource Specifications inside Jinja2 templates, you can fetch the data you need on the spot. 
+**Embed the data-source specification directly in your Jinja2 templates.** Declare *how* to fetch
+the data inside the template, and eds4jinja2 resolves it at render time — so you build dynamic,
+data-driven reports (HTML, LaTeX/PDF, or any text format) from SPARQL endpoints, in-memory RDF
+graphs, and tabular/JSON files **without writing data-loading glue code**.
 
-![test](https://github.com/meaningfy-ws/eds4jinja2/workflows/test/badge.svg)
+[![test](https://github.com/meaningfy-ws/eds4jinja2/actions/workflows/main.yml/badge.svg)](https://github.com/meaningfy-ws/eds4jinja2/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/meaningfy-ws/eds4jinja2/branch/master/graph/badge.svg)](https://codecov.io/gh/meaningfy-ws/eds4jinja2)
 [![Documentation Status](https://readthedocs.org/projects/eds4jinja2/badge/?version=latest)](https://eds4jinja2.readthedocs.io/en/latest/?badge=latest)
 
@@ -11,60 +13,119 @@ With Embedded Datasource Specifications inside Jinja2 templates, you can fetch t
 ![PyPI - Status](https://img.shields.io/pypi/status/eds4jinja2)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/eds4jinja2)
 ![PyPI - License](https://img.shields.io/pypi/l/eds4jinja2?color=green)
-![PyPI - Wheel](https://img.shields.io/pypi/wheel/eds4jinja2)
 
-Specify the data sources in your JINJA templates directly.
+## Why eds4jinja2?
 
-```jinja2
-{% set content, error = from_file(path).fetch_tree() %} \n
-content:  {{ content }}\n
-error: {{ error }}\n
+Generating a report usually tangles two jobs: **fetching the data** (Python code that queries
+endpoints, reads files, shapes DataFrames and assembles a context dict) and **presenting it** (a
+template). Every change to *what the report shows* forces a round-trip through the Python code.
+
+eds4jinja2 collapses that coupling: **the template itself declares its data sources.** Your Python
+code merely points the engine at a template and renders it — it stays agnostic of what data the
+report displays.
+
+This pays off when you:
+
+- iterate quickly on report content and queries — change the **template**, not the code;
+- want queries and their visualisation to live together and evolve together;
+- build many report variants over the same data;
+- need the same report to run against a **live SPARQL endpoint** *or* an **in-process graph** with
+  no code change.
+
+**Problems it solves**
+
+- ❌ bespoke context-building / data-plumbing code for every report → ✅ none.
+- ❌ queries in Python, layout in templates, drifting apart → ✅ co-located and easy to change.
+- ❌ one source per report → ✅ one template, many heterogeneous sources (endpoint + file + graph).
+- ❌ "needs a running SPARQL server" → ✅ query an in-memory `rdflib`/`oxigraph` graph, server-less.
+- ❌ slow, query-bound reports → ✅ opt-in parallel pre-fetch.
+
+## How it works
+
+eds4jinja2 adds **data-source builders** as Jinja globals. In a template you call one, optionally
+set a query, and fetch. Every fetch returns a fail-safe `(content, error)` pair — a failure is
+surfaced *into* the template rather than crashing the render:
+
+```jinja
+{% set rows, error = from_endpoint(endpoint).with_query("SELECT * WHERE { ?s ?p ?o } LIMIT 10").fetch_tabular() %}
+{% set tree, error = from_file("config.json").fetch_tree() %}
 ```
 
-```jinja2
-{% set content, error =
-    from_endpoint(endpoint).with_query(query_string).fetch_tabular() %}
-content:  {{ content }} \n
-error: {{ error }} \n
-```
+`fetch_tabular()` returns a pandas `DataFrame`; `fetch_tree()` returns a nested dict (JSON /
+SPARQL-JSON). The data context is generated *during* rendering, so `template.render()` needs no
+pre-built context.
 
-# Installation
+## Installation
 
-```shell script
+```shell
 pip install eds4jinja2
-```
-
-For the optional fast in-memory SPARQL engine (oxigraph), install the extra:
-
-```shell script
+# optional fast in-memory SPARQL engine (oxigraph):
 pip install eds4jinja2[oxigraph]
 ```
 
-# Usage
+Requires Python 3.11+.
 
-[Read the docs here](https://eds4jinja2.readthedocs.io/en/latest/)  
+## Quick start
+
+**A. Render a template through the eds4jinja2 environment**
+
+```python
+from jinja2 import DictLoader
+from eds4jinja2 import build_eds_environment
+
+env = build_eds_environment(loader=DictLoader({
+    "report.txt": "{% set rows, err = from_file('data.csv').fetch_tabular() %}"
+                  "Rows: {{ rows | length }}\n{{ rows.to_string() }}",
+}))
+print(env.get_template("report.txt").render())   # data is fetched while rendering
+```
+
+**B. Drive a whole report folder with the `mkreport` CLI**
+
+```shell
+mkreport --target ./report --output ./out
+```
+
+The target folder follows a small convention:
+
+```
+report/
+├── config.json     # { "template": "main.html", "conf": { "default_endpoint": "...", ... } }
+├── templates/      # main.html and any includes
+└── static/         # css/js/images, copied into the output (tree preserved)
+```
+
+`config.json` names the entry template and carries a `conf` object of variables available to all
+templates. Set `"template_flavour_syntax": "latex"` for LaTeX templates.
+
+## Data sources
+
+| builder | source | `fetch_tabular` | `fetch_tree` |
+|---|---|:--:|:--:|
+| `from_file(path)` | CSV/TSV/Excel and JSON/YAML/TOML files | ✅ | ✅ |
+| `from_endpoint(url)` | a remote SPARQL endpoint | ✅ | ✅ |
+| `from_graph(graph)` (alias `from_memory`) | an in-process `rdflib.Graph`, `pyoxigraph` store, or `query(sparql)` callable | ✅ | ✅ |
+| `from_rdf(sources, engine="rdflib")` | RDF file(s)/URL(s) loaded into an in-memory graph (`rdflib` or `oxigraph`) | ✅ | ✅ |
+| `from_rdf_file(path)` | a single RDF file (legacy; superseded by `from_rdf`) | ✅ | — |
 
 ## In-memory graph data sources
 
-Besides a remote SPARQL endpoint (`from_endpoint`) and tabular/RDF files, reports can be
-rendered against an **in-process RDF graph** — no SPARQL server required. Two builders are
-available in templates:
+Render reports against an **in-process RDF graph** — no SPARQL server required:
 
-- `from_graph(graph)` — query an in-memory graph/store you already hold (an `rdflib.Graph`,
-  a `pyoxigraph` store, or any `query(sparql)` callable). Alias: `from_memory`.
-- `from_rdf(sources, engine="rdflib")` — load one or more RDF files/URLs into an in-memory
-  graph once (engine: `"rdflib"` default, or `"oxigraph"`) and query it. Both tabular
-  (`fetch_tabular`) and tree (`fetch_tree`) results are supported.
+- `from_graph(graph)` (alias `from_memory`) — query an `rdflib.Graph`, a `pyoxigraph` store, or any
+  `query(sparql)` callable you already hold.
+- `from_rdf(sources, engine="rdflib")` — load one or more RDF files/URLs into an in-memory graph
+  once (engine `"rdflib"` default, or `"oxigraph"`) and query it; tabular and tree results.
 
-To render an **existing report against an in-memory graph with the templates unchanged**,
-inject a builder that overrides `from_endpoint` (which the templates already call):
+To render an **existing report against an in-memory graph with the templates unchanged**, inject a
+builder that overrides `from_endpoint` (which the templates already call):
 
 ```python
 import rdflib
 from eds4jinja2 import InMemorySPARQLDataSource
 from eds4jinja2.services.report_builder import ReportBuilder
 
-graph = rdflib.Graph().parse("dataset.ttl")  # the consumer owns loading/manipulation
+graph = rdflib.Graph().parse("dataset.ttl")  # the consumer owns loading / manipulation
 ReportBuilder(
     "report/",
     external_data_source_builders={"from_endpoint": lambda _endpoint: InMemorySPARQLDataSource(graph)},
@@ -74,22 +135,31 @@ ReportBuilder(
 ## Parallel report execution
 
 For large reports whose runtime is dominated by SPARQL query latency, set `parallelism` in the
-report `config.json` to pre-warm all data fetches concurrently before rendering:
+report `config.json` to pre-fetch all data concurrently before rendering:
 
 ```json
 { "template": "report.html", "conf": {}, "parallelism": 16 }
 ```
 
-Execution is threads-only and **all-or-nothing** (any fetch failure aborts the report, no
-partial output); results are staged in a temp folder that is cleaned up afterwards. With
-`parallelism` unset or `1` the behaviour is exactly the previous sequential render. Threaded
-speed-up is real for remote endpoints and oxigraph in-memory graphs (both release the GIL);
-rdflib in-memory queries are GIL-bound (correct, limited speed-up).
+Execution is threads-only and **all-or-nothing** (any fetch failure aborts the report, no partial
+output); results are staged in a temp folder that is cleaned up afterwards. With `parallelism`
+unset or `1` the behaviour is exactly the previous sequential render. Threaded speed-up is real for
+remote endpoints and `oxigraph` in-memory graphs (both release the GIL); `rdflib` in-memory queries
+are GIL-bound (correct, limited speed-up).
+
+## Documentation
+
+Full documentation (concepts, the `ReportBuilder` API, extending with new data sources):
+[eds4jinja2.readthedocs.io](https://eds4jinja2.readthedocs.io/en/latest/)
 
 ## Contributing
-You are more than welcome to help expand and mature this project. We adhere to [Apache code of conduct](https://www.apache.org/foundation/policies/conduct), please follow it in all your interactions on the project.   
-When contributing to this repository, please first discuss the change you wish to make via issue, email, or any other method with the maintainers of this repository before making a change.
 
-## Licence 
+You are more than welcome to help expand and mature this project. We adhere to the
+[Apache code of conduct](https://www.apache.org/foundation/policies/conduct); please follow it in
+all your interactions on the project. When contributing, please first discuss the change you wish
+to make via an issue, email, or another method with the maintainers before making a change.
+
+## Licence
+
 This project is licensed under [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
 Powered by [Meaningfy](https://github.com/meaningfy-ws).

--- a/tests/unit/adapters/test_local_sparql_ds.py
+++ b/tests/unit/adapters/test_local_sparql_ds.py
@@ -1,127 +1,88 @@
 """
-test_sparql_ds.py
-Date:  25/09/2020
-Author: Laurentiu Mandru
-Email: mclaurentiu79@gmail.com
-"""
-import os
-import pathlib
-import pytest
-from eds4jinja2 import RDFFileDataSource
-import unittest
+test_local_sparql_ds.py
 
+Tests for RDFFileDataSource (query a local RDF file with SPARQL). Paths are anchored on the
+shared `test_data_dir` fixture so the tests actually load the fixture graph regardless of the
+working directory, and the tabular fetches assert on the real query result.
+"""
+import pytest
+
+from eds4jinja2 import RDFFileDataSource
 from eds4jinja2.models.data_source import UnsupportedRepresentation
 
-
-def test_load_local_sparql_fetch_tabular():
-    local_rdf_ds = RDFFileDataSource(
-        str(pathlib.Path("../test_data/shacl.example.shapes.ttl")))
-
-    local_rdf_ds.with_query("""SELECT *
-            WHERE {
-                 ?s ?p ?o
-            }
-            limit 10""")
-    local_rdf_ds.fetch_tabular()
+SPO_QUERY = "SELECT * WHERE { ?s ?p ?o } LIMIT 10"
 
 
-def test_load_local_sparql_fetch_tabular_without_query():
-    local_rdf_ds = RDFFileDataSource(
-        str(pathlib.Path("../test_data/shacl.example.shapes.ttl")))
+@pytest.fixture
+def shapes_ttl(test_data_dir):
+    return str(test_data_dir / "shacl.example.shapes.ttl")
 
-    local_rdf_ds.with_query("")
-    result, error_string = local_rdf_ds.fetch_tabular()
+
+@pytest.fixture
+def spo_query_file(test_data_dir):
+    return str(test_data_dir / "queries" / "spo_limit_10.txt")
+
+
+def test_load_local_sparql_fetch_tabular(shapes_ttl):
+    data_frame, error = RDFFileDataSource(shapes_ttl).with_query(SPO_QUERY).fetch_tabular()
+    assert error is None
+    assert not data_frame.empty
+    assert set(data_frame.columns) == {"s", "p", "o"}
+    assert len(data_frame) <= 10
+
+
+def test_load_local_sparql_fetch_tabular_without_query(shapes_ttl):
+    result, error_string = RDFFileDataSource(shapes_ttl).with_query("").fetch_tabular()
+    assert result is None
     assert error_string == "The query is empty."
 
 
-def test_load_local_sparql_substitution():
-    local_rdf_ds = RDFFileDataSource(
-        str(pathlib.Path("../test_data/shacl.example.shapes.ttl")))
-
-    local_rdf_ds.with_query("""SELECT *
-            WHERE {
-                 ~a ~b ~c
-            }
-            limit 10""", {'a': '?s', 'b': '?p', 'c': '?o'})
-    assert local_rdf_ds.__query__ == """SELECT *
-            WHERE {
-                 ?s ?p ?o
-            }
-            limit 10"""
+def test_load_local_sparql_substitution(shapes_ttl):
+    local_rdf_ds = RDFFileDataSource(shapes_ttl).with_query(
+        "SELECT * WHERE { ~a ~b ~c } LIMIT 10", {'a': '?s', 'b': '?p', 'c': '?o'})
+    assert local_rdf_ds.__query__ == "SELECT * WHERE { ?s ?p ?o } LIMIT 10"
 
 
-def test_load_local_query_from_file_sparql_fetch_tabular():
-    local_rdf_ds = RDFFileDataSource(
-        str(pathlib.Path("../test_data/shacl.example.shapes.ttl")))
+def test_load_local_query_from_file_sparql_fetch_tabular(shapes_ttl, spo_query_file):
+    data_frame, error = RDFFileDataSource(shapes_ttl).with_query_from_file(spo_query_file).fetch_tabular()
+    assert error is None
+    assert not data_frame.empty
+    assert set(data_frame.columns) == {"s", "p", "o"}
 
-    local_rdf_ds.with_query_from_file(pathlib.Path("./tests/test_data/queries/spo_limit_10.txt"))
-    local_rdf_ds.fetch_tabular()
 
-
-def test_load_local_query_from_file_and_prefixes():
-    local_rdf_ds = RDFFileDataSource(
-        str(pathlib.Path("../test_data/shacl.example.shapes.ttl")))
-
-    local_rdf_ds.with_query_from_file(pathlib.Path("./tests/test_data/queries/spo_limit_10.txt"), None, "PREFIX TEST")
+def test_load_local_query_from_file_and_prefixes(shapes_ttl, spo_query_file):
+    local_rdf_ds = RDFFileDataSource(shapes_ttl).with_query_from_file(spo_query_file, None, "PREFIX TEST")
     assert local_rdf_ds.__query__.startswith("PREFIX TEST")
 
 
-def test_load_local_query_and_prefixes():
-    local_rdf_ds = RDFFileDataSource(
-        str(pathlib.Path("../test_data/shacl.example.shapes.ttl")))
-
-    local_rdf_ds.with_query("""SELECT *
-            WHERE {
-                 ?s ?p ?o
-            }
-            limit 10""", None, "PREFIX TEST")
+def test_load_local_query_and_prefixes(shapes_ttl):
+    local_rdf_ds = RDFFileDataSource(shapes_ttl).with_query(SPO_QUERY, None, "PREFIX TEST")
     assert local_rdf_ds.__query__.startswith("PREFIX TEST")
 
 
-def test_load_local_query_from_file_substitution():
-    local_rdf_ds = RDFFileDataSource(
-        str(pathlib.Path("../test_data/shacl.example.shapes.ttl")))
-
-    local_rdf_ds.with_query_from_file(pathlib.Path("./tests/test_data/queries/spo_limit_10.txt"),
-                                      {'substitution_placeholder': 'after_substitution'})
+def test_load_local_query_from_file_substitution(shapes_ttl, spo_query_file):
+    local_rdf_ds = RDFFileDataSource(shapes_ttl).with_query_from_file(
+        spo_query_file, {'substitution_placeholder': 'after_substitution'})
     assert 'after_substitution' in local_rdf_ds.__query__
     assert '~substitution_placeholder' not in local_rdf_ds.__query__
 
 
-def test_load_local_query_from_file_and_direct_text_sparql_fetch_tabular():
-    local_rdf_ds = RDFFileDataSource(
-        str(pathlib.Path("../test_data/shacl.example.shapes.ttl")))
-
-    local_rdf_ds.with_query_from_file(pathlib.Path("./tests/test_data/queries/spo_limit_10.txt"))
+def test_setting_query_twice_raises(shapes_ttl, spo_query_file):
+    local_rdf_ds = RDFFileDataSource(shapes_ttl).with_query_from_file(spo_query_file)
     with pytest.raises(Exception):
-        local_rdf_ds.with_query("""SELECT *
-                WHERE {
-                     ?s ?p ?o
-                }
-                limit 10""")
-    local_rdf_ds.fetch_tabular()
+        local_rdf_ds.with_query(SPO_QUERY)
+    # the originally-set query still resolves
+    data_frame, error = local_rdf_ds.fetch_tabular()
+    assert error is None and not data_frame.empty
 
 
-def test_load_local_sparql_fetch_tree():
+def test_load_local_sparql_fetch_tree_unsupported(shapes_ttl):
     with pytest.raises(UnsupportedRepresentation):
-        local_rdf_ds = RDFFileDataSource(
-            str(pathlib.Path("../test_data/shacl.example.shapes.ttl")))
-        local_rdf_ds.with_query("""SELECT *
-                WHERE {
-                     ?s ?p ?o
-                }
-                limit 10""")
-        local_rdf_ds._fetch_tree()
+        RDFFileDataSource(shapes_ttl).with_query(SPO_QUERY)._fetch_tree()
 
 
-def test_load_local_sparql_fetch_tabular_inexistent_file():
-    local_rdf_ds = RDFFileDataSource(
-        str(pathlib.Path("inexistent.ttl")))
-
-    local_rdf_ds.with_query("""SELECT *
-            WHERE {
-                 ?s ?p ?o
-            }
-            limit 10""")
-    result = local_rdf_ds.fetch_tabular()
-    assert "[Errno 2] No such file or directory" in str(result)
+def test_load_local_sparql_fetch_tabular_inexistent_file(test_data_dir):
+    local_rdf_ds = RDFFileDataSource(str(test_data_dir / "does_not_exist.ttl")).with_query(SPO_QUERY)
+    result, error = local_rdf_ds.fetch_tabular()
+    assert result is None
+    assert "No such file or directory" in str(error)

--- a/tests/unit/services/test_report_builder.py
+++ b/tests/unit/services/test_report_builder.py
@@ -10,9 +10,26 @@ import shutil
 from unittest.mock import Mock
 
 import pytest
+import rdflib
+from eds4jinja2 import InMemorySPARQLDataSource
 from eds4jinja2.services.report_builder import ReportBuilder
-from eds4jinja2.models.collections import deep_update
 from bs4 import BeautifulSoup
+
+# A tiny in-process graph so make_document renders the dqgen-style template fully OFFLINE
+# (the template's section runs `select ?class (count(?instance) as ?instances) ...`).
+INSTANCES_TTL = """
+@prefix ex: <http://example.org/> .
+ex:a a ex:Thing .
+ex:b a ex:Thing .
+ex:c a ex:Person .
+"""
+
+
+def _in_memory_endpoint_builders():
+    graph = rdflib.Graph()
+    graph.parse(data=INSTANCES_TTL, format="turtle")
+    # override the builder the templates already call, so no live SPARQL endpoint is hit
+    return {"from_endpoint": lambda _endpoint: InMemorySPARQLDataSource(graph)}
 
 
 @pytest.fixture(scope="function")
@@ -50,7 +67,8 @@ def test_report_builder_make_document(sample_data_path):
     before_listener = Mock()
     after_listener = Mock()
 
-    report_builder = ReportBuilder(target_path=sample_data_path, output_path=pathlib.Path(sample_data_path) / "output")
+    report_builder = ReportBuilder(target_path=sample_data_path, output_path=pathlib.Path(sample_data_path) / "output",
+                                   external_data_source_builders=_in_memory_endpoint_builders())
 
     report_builder.add_before_rendering_listener(before_listener)
     report_builder.add_after_rendering_listener(after_listener)
@@ -74,7 +92,3 @@ def test_report_builder_make_latex_document(sample_data_path_latex):
     report_builder.make_document()
     assert (out_path / "main.tex").exists()
     shutil.rmtree(out_path)
-
-
-
-


### PR DESCRIPTION
Test-quality fixes (no production-code changes) and a README overhaul.

## Tests
- **`test_local_sparql_ds`**: the three `fetch_tabular()` tests pointed at a non-existent `../test_data/...` path and asserted nothing — `RDFFileDataSource`'s parse+query+DataFrame path was never actually tested (fail-safe swallowed the FileNotFoundError → green). Now anchored on the shared `test_data_dir` fixture and assert on the real result (non-empty DataFrame, `s/p/o` columns).
- **`test_report_builder_make_document`**: was hitting the **live EU SPARQL endpoint** (~20s, flaky) inside the unit suite. Now injects an in-memory `from_endpoint` (a tiny rdflib graph) so it renders the dqgen-style template fully **offline** — exercising the injection seam + in-memory source. `<h1>` assertion preserved.
- Net: default unit suite ~28s → **~2.4s**, no network in the default gate. 109 passed, flake8 clean.

## Docs
- README rewritten: **Why / problems it solves**, **How it works**, runnable **Quick start** (env render + `mkreport` CLI + target-folder layout), and a **data-sources capability table**.
- Cleaned broken `\n` artifacts in snippets; modernised the CI badge URL.
- Note: PyPI version/status badges are dynamic and already read 1.0.0 / Beta — the earlier mismatch was shields/PyPI cache lag, not a config problem.

No source under `eds4jinja2/` changed.